### PR TITLE
chore: Delete tslint form vscode/extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
     "recommendations": [
         "esbenp.prettier-vscode",
         "dbaeumer.vscode-eslint",
-        "ms-vscode.vscode-typescript-tslint-plugin",
         "steoates.autoimport",
         "stringham.move-ts",
         "streetsidesoftware.code-spell-checker"


### PR DESCRIPTION
Delete deprecated tslint plugin from the recommendations for vscode.

https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin