### PR TITLE
fix: change compile target to ES2021 due to TS18028

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,27 +4,26 @@
 name: Node.js CI
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+    push:
+        branches: ["master"]
+    pull_request:
+        branches: ["master"]
 
 jobs:
-  build:
+    build:
+        runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [20.x, 22.x]
+                # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install --prefer-offline
-    - run: npm run build -- --noEmit
-    - run: npm run lint
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - run: npm install --prefer-offline
+            - run: npm run build -- --noEmit
+            - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
         "husky": "^8.0.3",
         "prettier": "^2.8.8",
         "pretty-quick": "^3.1.3",
-        "typescript": "^5.1.3"
+        "typescript": "^5.6.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "devDependencies": {
         "@commitlint/cli": "^17.6.5",
         "@commitlint/config-conventional": "^17.6.5",
-        "@types/node": "^16.18.36",
+        "@types/node": "^20.17.4",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",
         "eslint": "^8.43.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,14 @@
     /* Documentation: https://www.typescriptlang.org/docs/handbook/compiler-options.html */
     "compilerOptions": {
         /* Basic options */
-        "target": "es5",
+        "target": "ES2021",
         "module": "commonjs",
-        "lib": ["es2015", "dom", "dom.iterable", "esnext"],
         "allowJs": false,
         "jsx": "preserve",
         "skipLibCheck": false,
         "isolatedModules": false,
         "outDir": "lib",
         "declaration": true,
-
         /* Strict Type-Checking Options */
         "strict": true,
         "noImplicitAny": true,
@@ -20,13 +18,11 @@
         "strictPropertyInitialization": false,
         "noImplicitThis": true,
         "alwaysStrict": true,
-
         /* Additional Checks */
         "noUnusedLocals": false,
         "noUnusedParameters": false,
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": false,
-
         /* Module Resolution Options */
         "moduleResolution": "node",
         "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
- fix: change compile target to ES2021 due to TS18028
- test: test with node 20 and 22
- chore: udpate typescript: