### PR TITLE
chore: upgrade devDependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,8 +5,6 @@
     },
     "extends": [
         "eslint:recommended",
-        "prettier",
-        "plugin:prettier/recommended",
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended"
     ],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,4 @@ jobs:
             - run: npm install --prefer-offline
             - run: npm run build -- --noEmit
             - run: npm run lint
+            - run: npm run format:check

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx --no-install pretty-quick --staged
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -48,6 +48,13 @@
         "tabWidth": 4,
         "endOfLine": "lf"
     },
+    "lint-staged": {
+        "*.{js,ts,json}": [
+            "prettier --write",
+            "eslint --fix"
+        ],
+        "*.md": "prettier --write"
+    },
     "dependencies": {
         "deepmerge": "^4.3.1"
     },
@@ -61,8 +68,8 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "husky": "^9.1.7",
+        "lint-staged": "^17.0.5",
         "prettier": "^2.8.8",
-        "pretty-quick": "^3.1.3",
         "typescript": "^5.6.3"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
         "deepmerge": "^4.3.1"
     },
     "devDependencies": {
-        "@commitlint/cli": "^17.6.5",
-        "@commitlint/config-conventional": "^17.6.5",
+        "@commitlint/cli": "^21.0.1",
+        "@commitlint/config-conventional": "^21.0.1",
         "@types/node": "^24.12.4",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "scripts": {
         "build": "tsc",
         "dev": "tsc -w",
+        "format": "prettier --write \"**/*.{ts,js,json,md}\"",
+        "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
         "lint": "eslint \"src/**/*.ts\"",
         "prepare": "husky && npm run build"
     },
@@ -65,11 +67,9 @@
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",
         "eslint": "^8.43.0",
-        "eslint-config-prettier": "^8.8.0",
-        "eslint-plugin-prettier": "^4.2.1",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.5",
-        "prettier": "^2.8.8",
+        "prettier": "^3.8.3",
         "typescript": "^5.6.3"
     },
     "peerDependencies": {


### PR DESCRIPTION
- chore: upgrade commitlint
- chore: replace pretty-quick with lint-staged
- chore: separate prettier from eslint and upgrade to v3:
    - Remove eslint-plugin-prettier and eslint-config-prettier
    - Upgrade prettier to ^3.8.3
    - Add `npm run format` script for running prettier manually
